### PR TITLE
Automount OneDrive folder

### DIFF
--- a/files/onedrive/media-onedrive.automount
+++ b/files/onedrive/media-onedrive.automount
@@ -1,0 +1,7 @@
+Description=Automount Onedrive
+
+[Automount]
+Where=/media/onedrive
+
+[Install]
+WantedBy=multi-user.target

--- a/files/onedrive/rclonefs
+++ b/files/onedrive/rclonefs
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Credit to https://github.com/ncw/rclone/wiki/rclone-fstab-mount-helper-script
+remote=$1
+mountpoint=$2
+shift 2
+
+# Process -o parameters
+while getopts :o: opts; do
+    case $opts in
+        o)
+            params=${OPTARG//,/ }
+            for param in $params; do
+                if [ "$param" == "rw"   ]; then continue; fi
+                if [ "$param" == "ro"   ]; then continue; fi
+                if [ "$param" == "dev"  ]; then continue; fi
+                if [ "$param" == "suid" ]; then continue; fi
+                if [ "$param" == "exec" ]; then continue; fi
+                if [ "$param" == "auto" ]; then continue; fi
+                if [ "$param" == "nodev" ]; then continue; fi
+                if [ "$param" == "nosuid" ]; then continue; fi
+                if [ "$param" == "noexec" ]; then continue; fi
+                if [ "$param" == "noauto" ]; then continue; fi
+                if [[ $param == x-systemd.* ]]; then continue; fi
+                trans="$trans --$param"
+            done
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG"
+            ;;
+    esac
+done
+
+# exec rclone
+trans="$trans $remote $mountpoint"
+PATH=$PATH rclone mount $trans &
+
+out=`ls -l $dst`
+until [ "$out" != 'total 0' ]; do
+    out=`ls -l $dst`
+    sleep 1
+done
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,3 +80,7 @@
 - include: openshift.yml
   tags:
     - openshift
+
+- include: onedrive.yml
+  tags:
+    - onedrive

--- a/tasks/onedrive.yml
+++ b/tasks/onedrive.yml
@@ -1,0 +1,38 @@
+---
+# https://blog.tomecek.net/post/automount-with-systemd/
+- name: Install rclone
+  apt:
+    name: rclone
+  become: yes
+
+- name: Create OneDrive mount point
+  file:
+    path: /media/onedrive
+    state: directory
+  become: yes
+
+- name: Copy rclonefs mount helper script
+  copy:
+    src: onedrive/rclonefs
+    dest: /usr/local/bin # can't go into .local/bin
+    mode: 0755
+  become: yes
+
+- name: Copy systemd automount file
+  copy:
+    src: onedrive/media-onedrive.automount
+    dest: /etc/systemd/system
+  become: yes
+
+- name: Copy systemd mount file
+  template:
+    src: media-onedrive.mount.j2
+    dest: /etc/systemd/system/media-onedrive.mount
+  become: yes
+
+- name: Enable systemd automount
+  systemd:
+    name: media-onedrive.automount
+    enabled: yes
+    state: started
+  become: yes

--- a/templates/media-onedrive.mount.j2
+++ b/templates/media-onedrive.mount.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=rclone mount for OneDrive
+Requires=systemd-networkd.service
+Wants=network-online.target
+After=network-online.target
+
+[Mount]
+What=rclonefs#onedrive:
+Where=/media/onedrive
+Type=fuse
+Options=auto,config={{ xdg.XDG_CONFIG_HOME }}/rclone/rclone.conf,allow-other,default-permissions
+TimeoutSec=30
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #51. User must still run `rclone config` to create the OneDrive entry and establish credentials